### PR TITLE
Add README and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Editais de Concurso
+
+This project contains a Streamlit application that analyzes PDF files of public notices ("editais") using the OpenAI API.
+
+## Installation
+
+1. Create a virtual environment (optional) and activate it.
+2. Install the required packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Configuration
+
+Store your OpenAI API key in `.streamlit/secrets.toml` so it is available to the app. The file should look like:
+
+```toml
+[general]
+openai_api_key = "sk-YOUR_KEY_HERE"
+```
+
+The path `.streamlit/secrets.toml` is included in `.gitignore` to avoid accidentally committing secrets.
+
+## Running
+
+Launch the Streamlit app with:
+
+```bash
+streamlit run appeditais.py
+```
+
+The application will prompt for the required information and display the generated analysis.


### PR DESCRIPTION
## Summary
- document how to install requirements, set up API key and run Streamlit
- clarify usage rights with an MIT license

## Testing
- `python -m py_compile appeditais.py`

------
https://chatgpt.com/codex/tasks/task_e_684d0bb2a24c832a9243b1eb14e11d8b